### PR TITLE
Try destroying ImporterLog table

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -59,7 +59,7 @@ export class ApiLambdaCrudDynamoDBStack extends Stack {
 				type: AttributeType.STRING,
 			},
 			tableName: IMPORTER_LOG_TABLE_NAME,
-			removalPolicy: RemovalPolicy.RETAIN,
+			removalPolicy: RemovalPolicy.DESTROY,
 		});
 
 		const API_KEYS = process.env.API_KEYS!;


### PR DESCRIPTION
This is to try to address the CDK deploy failure from the last PR complaining that the ImporterLog table already exists. (If I get the right dynamodb permission, I'll try just manually deleting it if this doesn't help.)