### PR TITLE
fix: also add dependency to permissionsNode

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -112,7 +112,9 @@ export class ApiLambdaCrudDynamoDBStack extends Stack {
 
 		// Grant the Lambda function read access to the DynamoDB table
 		getEventsLambda.node.addDependency(eventsTable);
+		getEventsLambda.permissionsNode.addDependency(eventsTable);
 		importerLambda.node.addDependency(importerLogTable);
+		importerLambda.permissionsNode.addDependency(importerLogTable);
 		eventsTable.grantReadWriteData(getEventsLambda);
 		importerLogTable.grantReadWriteData(importerLambda);
 


### PR DESCRIPTION
This probably won't make a difference because I see the generated template already has the expected dependencies specified on the "*ServiceRoleDefaultPolicy" resources.