### PR TITLE
fix: make DynamoDB client not target localhost

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -31,6 +31,7 @@ jobs:
         run: npm run cdk bootstrap
       - name: Deploy
         env:
+          BUILD_ENV: 'production'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           API_KEYS: ${{ secrets.API_KEYS }}
           MEETUP_GROUP_NAMES: ${{ secrets.MEETUP_GROUP_NAMES }}


### PR DESCRIPTION
We were defaulting to NODE_ENV = "development" without passing this