### PR TITLE
Feat/add pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cdk.context.json
 .DS_Store
 docker/
 api-logs.txt
+.vscode/

--- a/lambdas/events.ts
+++ b/lambdas/events.ts
@@ -39,8 +39,8 @@ async function getMeetupEvents(
 		FilterExpression: 'attribute_not_exists(DeletedAtDateTime)',
 		KeyConditionExpression: makeKeyConditionExpression(options),
 		ExpressionAttributeValues: makeExpressionAttributeValues(options),
-		ExclusiveStartKey: options.page ? b64Decode(options.page) : undefined, //Pagination not implemented
-		Limit: options.count, //it can be the number of events to return in pagination
+		ExclusiveStartKey: options.page ? b64Decode(options.page) : undefined,
+		Limit: options.count,
 	});
 
 	console.log({ queryCommand }); // eslint-disable-line no-console

--- a/lambdas/types/MeetupFutureEventsPayload.ts
+++ b/lambdas/types/MeetupFutureEventsPayload.ts
@@ -16,6 +16,10 @@ export interface MeetupEvent {
 	images: Image[];
 	deletedAt?: Date;
 }
+export interface MeetupEvents {
+	pageInfo: PageInfo;
+	events: MeetupEvent[];
+}
 
 export function meetupEventFromDynamoDbItem(
 	item: Record<string, AttributeValue>,


### PR DESCRIPTION
- Retrieve lastEvaluatedKey after dynamo query and send it encoded in the API response payload
- Get `cursor` query parameter, decode it and add as ExclusiveStartKey at dynamo query to retrieve next page

New object `pageInfo` added in the response: e.g.
 ```
"pageInfo": {
        "endCursor": "MzA1MzcwMDExXzE3Mzc1MDU4MDAwMDA=",
        "hasNextPage": true
    },
```

or empty if it does not have next page: e.g.

 ```
"pageInfo": {
        "endCursor": "",
        "hasNextPage": false
    },
```

### How to test
add query `limit` to define number of events por page. If not added the default = 20
add query `cursor` do define the next page´s index

### Query examples
#### no limit defined (default)
`events?group=group-name`

#### get first page with limit
`events?group=group-name&limit=3`

#### get next page with limit
`events?group=group-name&limit=3&cursor=Mjk5MDA5MzI3XzE3MDcyNjU4MDAwMDA=`

#### get next page with default limit
`events?group=group-name&cursor=Mjk5MDA5MzI3XzE3MDcyNjU4MDAwMDA=`
